### PR TITLE
Fix warning

### DIFF
--- a/lib/gpt3_tokenizer.ex
+++ b/lib/gpt3_tokenizer.ex
@@ -122,7 +122,7 @@ defmodule Gpt3Tokenizer do
 
   defp get_pairs(word) do
     Enum.zip(
-      word |> Enum.slice(0..-2),
+      word |> Enum.slice(0..-2//1),
       word |> Enum.drop(1)
     )
   end


### PR DESCRIPTION
warning: negative steps are not supported in Enum.slice/2, pass 0..-2//1 instead