### PR TITLE
Update deps

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -22,8 +22,8 @@ defmodule Gpt3Tokenizer.MixProject do
 
   defp deps do
     [
-      {:jason, "~> 1.2"},
-      {:memoize, "~> 1.4"},
+      {:jason, "~> 1.4"},
+      {:memoize, "~> 1.4.3"},
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false}
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -5,6 +5,6 @@
   "makeup": {:hex, :makeup, "1.1.0", "6b67c8bc2882a6b6a445859952a602afc1a41c2e08379ca057c0f525366fc3ca", [:mix], [{:nimble_parsec, "~> 1.2.2 or ~> 1.3", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "0a45ed501f4a8897f580eabf99a2e5234ea3e75a4373c8a52824f6e873be57a6"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.16.1", "cc9e3ca312f1cfeccc572b37a09980287e243648108384b97ff2b76e505c3555", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}, {:nimble_parsec, "~> 1.2.3 or ~> 1.3", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "e127a341ad1b209bd80f7bd1620a15693a9908ed780c3b763bccf7d200c767c6"},
   "makeup_erlang": {:hex, :makeup_erlang, "0.1.1", "3fcb7f09eb9d98dc4d208f49cc955a34218fc41ff6b84df7c75b3e6e533cc65f", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "174d0809e98a4ef0b3309256cbf97101c6ec01c4ab0b23e926a9e17df2077cbb"},
-  "memoize": {:hex, :memoize, "1.4.1", "af853b4bbbf369dd050a9306b6d47d620b76f06935147a67a18751397a952d09", [:mix], [], "hexpm", "83bc06b9ff3815457cdb642ad6f3f02445d0e2948e835d3a92c1979853ef56ee"},
+  "memoize": {:hex, :memoize, "1.4.3", "ead4ba248291acbaecbfe7e68ed762d329dd9c29c727020c7393dda4060c4471", [:mix], [], "hexpm", "a75176b84b9ce92faaf567c82fcbc584ef95727e0827cb38606b0a197f7e47ef"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.3.1", "2c54013ecf170e249e9291ed0a62e5832f70a476c61da16f6aac6dca0189f2af", [:mix], [], "hexpm", "2682e3c0b2eb58d90c6375fc0cc30bc7be06f365bf72608804fb9cffa5e1b167"},
 }


### PR DESCRIPTION
I had errors with the `memoize` library and got errors when I tried to use this lib with our app. My `.tool-versions` file is as follows:

```
   1   │ elixir 1.15.5-otp-26
   2   │ erlang 26.0.2
```
Updating the deps has fixed this and I can now run this lib in our app. Would love to see a version bump with this so we can get this lib from hex and not from gh, as we're going to use it in product. (Also, a big thank you for this! It's great!)